### PR TITLE
Changed exec func to listen for 'close' signal instead of 'exit'

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ FTP.prototype.exec = function (cmds, callback) {
 			callback(err, { error: error || null, data: data });
 		callback = null; // Make sure callback is only called once, whether 'exit' event is triggered or not.
 	});
-	lftp.on('exit', function (code) {
+	lftp.on('close', function (code) {
 		if (callback)
 			callback(null, { error: error || null, data: data });
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ftps",
-	"version": "0.4.7",
+	"version": "0.4.8",
 	"author": {
 		"name"  : "Sébastien Chopin" ,
 		"email" : "atinux@gmail.com" ,
@@ -9,7 +9,10 @@
 	"contributors": [{
 		"name": "Steven Kissack",
 		"url": "https://github.com/stevokk"
-	}],
+	}, {
+		"name": "Tyler Finethy",
+		"url": "https://github.com/tylfin"
+		}],
 	"maintainers": ["atinux"],
 	"description": "FTP, FTPS and SFTP client for node.js, mainly a lftp wrapper.",
 	"keywords": ["ftp" , "ftps", "sftp", "node-ftp", "node-sftp", "node-ftps", "lftp"],
@@ -23,6 +26,8 @@
 	"dependencies": {
     "lodash": "^4.4.0"
 	},
-	"devDependencies": {},
+	"devDependencies": {
+	  "q": "^1.4.1"
+	},
 	"scripts" : {}
 }


### PR DESCRIPTION
When lftp listens for 'exit' signal, multiple running client connections can terminate -- sometimes prematurely, listening for close is safer.

Change lftp.on('exit') to lftp.on('close')
Add unittest
Add q devDependency