### PR TITLE
add execAsStream execution option

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
 		"node": ">=0.4.0"
 	},
 	"dependencies": {
-    "lodash": "^4.4.0"
-	},
-	"devDependencies": {
-	  "q": "^1.4.1"
-	},
-	"scripts" : {}
+                "duplex-child-process": "0.0.5",
+                "lodash": "^4.4.0"
+        },
+        "devDependencies": {
+                "q": "^1.4.1"
+        },
+        "scripts": {}
 }


### PR DESCRIPTION
Here is a PR that adds the execAsStream feature as per #38 

I don't really see how to test it programmatically since we would need a stable ftp server.

I use it 
 * with the `find` command to get a deep ls of a ftp server root
 * with the `cat` command to stream-pipe the content of a remote binary file

Up to now it has behaved as expected (both for the success case and the error case triggering and 'error'  event)

   var stream = (new lftp(config)).raw('find').execAsStream();
   stream.pipe(process.stdout);


