### PR TITLE
FIX : escaping ';'

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ FTP.prototype.escapeshell = function (cmd) {
   if (typeof cmd !== 'string') {
     return ''
   }
-  return cmd.replace(/([&"\s'$`\\])/g, '\\$1')
+  return cmd.replace(/([&"\s'$`\\;])/g, '\\$1')
 }
 
 FTP.prototype._escapeshell = function (cmd) {


### PR DESCRIPTION
Hi,

In case of ";" in filenames we need to escape it so it doesn't crash.

For instance
ftps.put("mylocalfile.txt", "my;weird_but_legal_filename.txt")

Thanks