### PR TITLE
FIX: do not escape special characters on user and password

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,13 @@ FTP.prototype._escapeshell = function (cmd) {
   return cmd
 }
 
+FTP.prototype._escapequote = function (cmd) {
+  if (typeof cmd !== 'string') {
+    return ''
+  }
+  return cmd.replace(/(")/g, '\\"')
+}
+
 FTP.prototype.prepareLFTPOptions = function () {
   var opts = []
 
@@ -107,7 +114,7 @@ FTP.prototype.prepareLFTPOptions = function () {
 
   var open = 'open'
   if (this.options.username) {
-    open += ' -u "' + this._escapeshell(this.options.username) + '","' + this._escapeshell(this.options.password) + '"'
+    open += ' -u "' + this._escapequote(this.options.username) + '","' + this._escapequote(this.options.password) + '"'
   }
   open += ' "' + this.options.host + '"'
   opts.push(open)


### PR DESCRIPTION
User and password fields are already between quotes: add the escape character '\' gives wrong password or username.