### PR TITLE
Add ftps.mkdir() to available chainable functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ ftps.put(pathToLocalFile, [pathToRemoteFile]) // alias: addFile
 ftps.get(pathToRemoteFile, [pathToLocalFile]) // download remote file and save to local path (if not given, use same name as remote file), alias: getFile
 ftps.mv(from, to) // alias move
 ftps.rm(file1, file2, ...) // alias remove
+ftps.mkdir(pathToNewDir, mode)
 ftps.rmdir(directory1, directory2, ...)
 ftps.mirror({
   remoteDir: '.', // optional, default: .

--- a/index.js
+++ b/index.js
@@ -269,4 +269,8 @@ FTP.prototype.mirror = function (opts) {
   return this.raw(raw)
 }
 
+FTP.prototype.mkdir = function (directory, mode) {
+  return this.raw('mkdir ' + mode + ' ' + directory)
+};
+
 module.exports = FTP


### PR DESCRIPTION
Adds support for creating new remote directory. Can be done as a chain command e.g. `ftps.mkdir(path, ['-p']).cd(path).addFile(file)`.

Credit: https://stackoverflow.com/a/31471640/4151151